### PR TITLE
Create itermCoprocessStarter.sh

### DIFF
--- a/itermCoprocessStarter.sh
+++ b/itermCoprocessStarter.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+TITLE=$(osascript -e 'tell application "iTerm" to get the name of the front window')
+if [[ ${TITLE} =~ "@" ]] ; then
+    FIRST="${TITLE#*@}"
+    if [[ ${FIRST} =~ ":" ]] ; then
+        HOST="${FIRST%%:*}"
+        export SUDOLIKEABOSS_DEFAULT_HOST="sudolikeaboss://${HOST}"
+    fi;
+fi;
+
+/usr/local/bin/sudolikeaboss


### PR DESCRIPTION
Maybe this interessts others,
I created a bash script that tries to get the Iterm title and extract the current hostname to suply it to sudolikeaboss.
With this hack 1PW can sugest the relevant passwords better. (URLs are like sudolikeaboss://<hostname>)
