### PR TITLE
Fix import path for Websocket client

### DIFF
--- a/websocketclient/client.go
+++ b/websocketclient/client.go
@@ -1,7 +1,7 @@
 package websocketclient
 
 import (
-	ws "code.google.com/p/go.net/websocket"
+	ws "golang.org/x/net/websocket"
 )
 
 type Codec interface {


### PR DESCRIPTION
The import path for the websocket client has changed and breaks the build, this PR corrects it.